### PR TITLE
🐛 fix: fix configuration menu plugin compatibility

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -105,7 +105,7 @@
         <colorSettingsPage implementation="cn.aprilviolet.highlightbracketpair.setting.HighlightBracketPairSettingsPage"/>
         <applicationConfigurable parentId="other"
                                  instance="cn.aprilviolet.highlightbracketpair.setting.BracketSettingsConfigurable"
-                                 id="org.intellij.sdk.settings.AppSettingsConfigurable" displayName="HighlightBracketPair"/>
+                                 id="cn.aprilviolet.highlightbracketpair.AppSettingsConfigurable" displayName="HighlightBracketPair"/>
         <applicationService serviceImplementation="cn.aprilviolet.highlightbracketpair.setting.HighlightBracketPairSettings"/>
     </extensions>
 


### PR DESCRIPTION
Hey @AprilViolet, I'd like to make you aware of a compatibility issue I ran into recently between your plugin and my [Toggler](https://github.com/Noorts/Toggler) plugin.

The configuration menus set up by our plugins use a class called `ApplicationConfigurable`, which is configured as an extension in our `plugin.xml`. This configuration includes an identifier which should be unique, else conflicts between plugins will occur and the configurations menu's won't show up.

Now, because we both used the JetBrains' plugin template the identifier in both our plugins was set to a default value. This caused an error for a developer using both plugins as discussed on the following GitHub [issue](https://github.com/Noorts/Toggler/issues/5).

I just pushed out an [update](https://github.com/Noorts/Toggler/commit/9835d4c236cf6b30e2c7b985e23b7b3476173e82) for my plugin to remedy the issue but would also highly recommend you to push out an update as I expect many other plugin developers have used the plugin template and haven't updated the value from the default one, causing conflicts if both plugins are installed.

Again, I highly recommend checking out the [issue](https://github.com/Noorts/Toggler/issues/5) for more information.