### PR TITLE
🐛 fix: fix NoClassDefFoundError caused by commons-collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - More language support.
 
+### Fixed
+
+- Fix NoClassDefFoundError about commons-collections on IDEA 2026.2. (#70)
+
 ## [1.4.3 - 2024.02.25]
 
 ### Fixed

--- a/src/main/java/cn/aprilviolet/highlightbracketpair/extend/XmlSupportedToken.java
+++ b/src/main/java/cn/aprilviolet/highlightbracketpair/extend/XmlSupportedToken.java
@@ -8,7 +8,6 @@ import com.intellij.openapi.editor.highlighter.HighlighterIterator;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.xml.XmlTokenType;
-import org.apache.commons.collections.CollectionUtils;
 
 import java.util.*;
 
@@ -31,7 +30,7 @@ public class XmlSupportedToken extends CustomSupportedToken {
         }
 
         List<Pair<IElementType, IElementType>> pairList = languagePairsMap.getOrDefault(xml, new ArrayList<>());
-        if (CollectionUtils.isEmpty(pairList)) {
+        if (pairList.isEmpty()) {
             pairList.add(new Pair<>(XmlTokenType.XML_START_TAG_START, XmlTokenType.XML_TAG_END));
             pairList.add(new Pair<>(XmlTokenType.XML_ATTRIBUTE_VALUE_START_DELIMITER,
                     XmlTokenType.XML_ATTRIBUTE_VALUE_END_DELIMITER));

--- a/src/main/java/cn/aprilviolet/highlightbracketpair/highlighter/DefaultAbstractBracketHighlighter.java
+++ b/src/main/java/cn/aprilviolet/highlightbracketpair/highlighter/DefaultAbstractBracketHighlighter.java
@@ -10,7 +10,6 @@ import com.intellij.lang.LanguageBraceMatching;
 import com.intellij.lang.PairedBraceMatcher;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.tree.IElementType;
-import org.apache.commons.collections.CollectionUtils;
 
 import java.util.*;
 
@@ -55,7 +54,7 @@ public class DefaultAbstractBracketHighlighter extends AbstractBracketHighlighte
     public List<Pair<IElementType, IElementType>> getSupportedBraceToken() {
         Language language = this.psiFile.getLanguage();
         List<Pair<IElementType, IElementType>> braceList = LANGUAGE_BRACE_PAIRS.get(language);
-        boolean emptyFlag = CollectionUtils.isEmpty(braceList);
+        boolean emptyFlag = braceList == null || braceList.isEmpty();
         if (Boolean.TRUE.equals(bracketPairSettings.getHighlightXmlFlag())) {
             if (emptyFlag) {
                 XmlSupportedToken.Singleton.INSTANCE.addSupported(language, LANGUAGE_BRACE_PAIRS);


### PR DESCRIPTION
Fixes #70

The plugin used CollectionUtils from commons-collections 3.x without declaring the dependency, it just happened to be on the IDE classpath. 2026.2 no longer exposes it to plugins, so every caret move threw NoClassDefFoundError. Both usages were trivial isEmpty checks, replaced them with plain null/isEmpty so the library isn't needed at all.